### PR TITLE
Bumped MailChimp API to v3 as v2 is no longer supported by MailChimp.

### DIFF
--- a/lib/omniauth/strategies/mailchimp.rb
+++ b/lib/omniauth/strategies/mailchimp.rb
@@ -46,7 +46,7 @@ module OmniAuth
           data = user_data
           endpoint = data["api_endpoint"]
           apikey = "#{@access_token.token}-#{data['dc']}"
-          response = @access_token.get("#{endpoint}/2.0/helper/account-details?apikey=#{apikey}").parsed
+          response = @access_token.get("#{endpoint}/3.0/").parsed
           if response["error"]
             case response["code"]
             when 109


### PR DESCRIPTION
MailChimp dropped support for v2 API last year, and it's no longer documented, and prone to issues. This PR changes the request for account details from v2 to v3.

This ensures better future support and also fixes a few permissions related issues authorizing non-Owner/Admin accounts using the strategy.