### PR TITLE
Allow passing full_host in options

### DIFF
--- a/lib/omniauth/strategies/mailchimp.rb
+++ b/lib/omniauth/strategies/mailchimp.rb
@@ -41,6 +41,14 @@ module OmniAuth
         }
       end
 
+      def callback_url
+        if options.full_host
+          options.full_host + script_name + callback_path + query_string
+        else
+          super
+        end
+      end
+
       def raw_info
         @raw_info ||= begin
           endpoint = user_data["api_endpoint"]


### PR DESCRIPTION
Not sure if this will apply to anyone else, but since our application identifies the account using a subdomain, Mailchimp's upcoming changes to require a fully-qualified callback URL for OAuth required changes on our end.

Since each user's subdomain will be unique, we had to set up a reserved subdomain to route all these requests through rather than relying on the default behavior which will pass https://<account_subdomain>.kindful.com as part of the callback URL and lead to a mismatch.

We'll run on this fork for now, but this allows us to pass in our reserved subdomain as the `full_host`, which did not seem possible before.