### PR TITLE
Upgrade omniauth from a vulnerable version

### DIFF
--- a/omniauth-mailchimp.gemspec
+++ b/omniauth-mailchimp.gemspec
@@ -2,7 +2,7 @@
 require File.expand_path('../lib/omniauth/mailchimp/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.add_dependency 'omniauth', '~> 1.0'
+  gem.add_dependency 'omniauth', '> 1.9.1'
 
   gem.authors = ["Steven Karas", "Florian Mhun"]
   gem.email = ["steven.karas@gmail.com", "florian.mhun@gmail.com"]

--- a/spec/omniauth/strategies/mailchimp_spec.rb
+++ b/spec/omniauth/strategies/mailchimp_spec.rb
@@ -4,12 +4,12 @@ require 'omniauth-mailchimp'
 describe OmniAuth::Strategies::Mailchimp do
   before :each do
     @request = double('Request')
-    @request.stub(:params) { {} }
   end
   
   subject do
     OmniAuth::Strategies::Mailchimp.new(nil, @options || {}).tap do |strategy|
       strategy.stub(:request) { @request }
+      strategy.stub(:script_name) { "" }
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 require 'bundler/setup'
 require 'rspec'
+require 'omniauth'
+
 Dir[File.expand_path('../support/**/*', __FILE__)].each { |f| require f }
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,4 +3,5 @@ require 'rspec'
 Dir[File.expand_path('../support/**/*', __FILE__)].each { |f| require f }
 
 RSpec.configure do |config|
+  OmniAuth.config.test_mode = true
 end


### PR DESCRIPTION
omniauth 1.9.1 is vulnerable to a high-severity CVE ([CVE-2015-9284](https://github.com/advisories/GHSA-ww4x-rwq6-qpgf))

There were already 2 failing tests on `master` so I fixed these first, then upgraded the dependency. I had to fix some tests again because of the new [Relative Root Apps support](https://github.com/omniauth/omniauth/releases/tag/v2.0.0) that was added in `omniauth` 2.0.0